### PR TITLE
Fix `[agent quickstarts]` url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ In production, you will want to host your own token server to generate tokens in
 
 ## Agent
 
-This example app requires an AI agent to communicate with. You can use one of our example agents in [livekit-examples](https://github.com/livekit-examples/), or create your own following one of our [agent quickstarts](https://docs.livekit.io/agents/quickstart/).
+This example app requires an AI agent to communicate with. You can use one of our example agents in [livekit-examples](https://github.com/livekit-examples/), or create your own following one of our [agent quickstarts](https://docs.livekit.io/agents/quickstarts/voice-agent/).


### PR DESCRIPTION
The README Agents section links to `[agent quickstarts](https://docs.livekit.io/agents/quickstart/)`.

https://docs.livekit.io/agents/quickstart/ 308 redirects to https://docs.livekit.io/agents/quickstarts/voice-assistant/

https://docs.livekit.io/agents/quickstarts/voice-assistant/ results in 404.

Browsing to https://docs.livekit.io/agents/ there is a `Quickstarts` section right at the top, but there is no direct link to it.

Clicking on the already expanded `Quickstarts` oddly collapses the Quickstarts section.

Clicking on the collapsed `Quickstarts` rewrites the url to the first quickstart url of https://docs.livekit.io/agents/quickstarts/s2s/.

None of these examples seem directly useful to this https://github.com/livekit-examples/android-voice-assistant repo.

So, I am at a bit of a loss of how to best correct this typo.

Consider declining this PR and considering this just an Issue report and fix it however you want to.