### PR TITLE
docs: update token server instructions to use project settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is a starter template for [LiveKit Agents](https://docs.livekit.io/agents/o
 This template is free for you to use or modify as you see fit.
 
 ## Getting started
-
-The easiest way to get this app running is with a sandbox token server and the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/).
+ 
+The easiest way to get this app running is with a [Token Server for LiveKit Cloud](https://cloud.livekit.io/projects/p_/settings/project) and the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/).
 
 First, enable the token server from your project's [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the sandbox ID.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This template is free for you to use or modify as you see fit.
 
 ## Getting started
 
-The easiest way to get this app running is with the [Sandbox for LiveKit Cloud](https://cloud.livekit.io/projects/p_/sandbox) and the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/).
+The easiest way to get this app running is with a sandbox token server and the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/).
 
-First, create a new [Sandbox Token Server](https://cloud.livekit.io/projects/p_mytc7vpzfkt/sandbox/templates/token-server) for your LiveKit Cloud project.
+First, enable the token server from your project's [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the sandbox ID.
 
 Then, run the following command to automatically clone this template and connect it to LiveKit Cloud:
 
@@ -23,7 +23,7 @@ Build and run the app in Android Studio.
 You'll also need an agent to speak with. Try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
 
 > [!NOTE]
-> To setup without the LiveKit CLI, clone the repository and edit the `TokenExt.kt` file to add either a `sandboxID` (if using a [Sandbox Token Server](https://cloud.livekit.io/projects/p_/sandbox/templates/token-server)), or a [manually generated](#token-generation) URL and token.
+> To setup without the LiveKit CLI, clone the repository and edit the `TokenExt.kt` file to add either a `sandboxID` (from your project's [Settings](https://cloud.livekit.io/projects/p_/settings/project) page), or a [manually generated](#token-generation) URL and token.
 
 ## Token generation
 


### PR DESCRIPTION
## Summary
- Updated sandbox token server instructions to point users to the project Settings page instead of the old sandbox templates page
- The token server is now auto-generated per project and enabled via a toggle in Settings

## Related
- livekit/web#3443